### PR TITLE
jan-26: PathFinding 알고리즘 버그 수정

### DIFF
--- a/CPP/NativeLib/NativeLib/PathFindService.h
+++ b/CPP/NativeLib/NativeLib/PathFindService.h
@@ -26,9 +26,9 @@ private:
 	int dx[8] = { 0, 1, 1, 1, 0, -1, -1, -1 };
 	int dy[8] = { 1, 1, 0, -1, -1, -1, 0, 1 };
 
-	int weight_h = 12;
-	int weight_g_straight = 10;
-	int weight_g_diagonal = 15;
+	int weight_h = 100;
+	int weight_g_straight = 100;
+	int weight_g_diagonal = 141;
 
 	int AstarH(Coordinates start_tile, Coordinates end_tile);
 


### PR DESCRIPTION
PathFinding 알고리즘이 맵 절반 가까이 훑는 것을 보고 이상하여 코드를 자세히 보니 알고리즘에 오류가 있었음.

스코어 계산할 때 '지금까지 온 거리' + '남은 휴리스틱 거리' 로 계산해야 하는데,  '지난 스코어' + '남은 휴리스틱 거리'로 계산 하고 있었음.

지금까지 온 거리를 기록하고 있지 않아서 새로운 unordered_map을 추가해서 구현하였음.

개선 결과 탐색 경로가 약 8000타일 -> 900타일로 감소하고 길도 더 잘 찾음.